### PR TITLE
Improve performance and update deps [SATURN-1057]

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,8 @@
 runtime: python37
+instance_class: F4
 automatic_scaling:
   min_instances: 1
-  max_instances: 100
+  max_instances: 20
   min_idle_instances: 1
 inbound_services:
 - warmup

--- a/arrow/server.py
+++ b/arrow/server.py
@@ -1,11 +1,9 @@
 import fastavro
 import urllib.request
 from sanic import response, Sanic
-from sanic_compress import Compress
 from arrow.translate import translate
 
 app = Sanic('arrow')
-Compress(app)
 
 
 @app.get('/_ah/warmup')

--- a/arrow/server.py
+++ b/arrow/server.py
@@ -1,9 +1,11 @@
 import fastavro
 import urllib.request
 from sanic import response, Sanic
+from sanic_compress import Compress
 from arrow.translate import translate
 
 app = Sanic('arrow')
+Compress(app)
 
 
 @app.get('/_ah/warmup')

--- a/arrow/translate.py
+++ b/arrow/translate.py
@@ -52,10 +52,10 @@ def _b64_decode(encoded_value):
 def _list_enums(schema):
     object_field = next(f for f in schema['fields'] if f['name'] == 'object')
     types = [t for t in object_field['type'] if t['name'] != 'Metadata']
-    enums = [(entity_type['name'], field['name'])
+    enums = {(entity_type['name'], field['name'])
              for entity_type in types
              for field in entity_type['fields']
-             for enum in field['type'] if isinstance(enum, dict) and enum['type'] == 'enum']
+             for enum in field['type'] if isinstance(enum, dict) and enum['type'] == 'enum'}
     return enums
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ gunicorn==19.9.0
 pytest==5.0.1
 pytest-asyncio==0.10.0
 sanic==19.6.3
-sanic_compress==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fastavro==0.22.3
+fastavro==0.22.4
 gunicorn==19.9.0
 pytest==5.0.1
 pytest-asyncio==0.10.0
-sanic==19.6.2
+sanic==19.6.3
+sanic_compress==0.1.1


### PR DESCRIPTION
~Gzip JSON response to avoid GAE 32MB response size limit.~ GAE gzips automatically if you ask for it in the request headers.
Use set instead of list comprehension (much much faster lookups).
Increase instance class for more CPU speed.