### PR TITLE
Update name of Metadata object to match change in Gen3

### DIFF
--- a/arrow/translate.py
+++ b/arrow/translate.py
@@ -22,7 +22,7 @@ class Translator:
 
         enums = _list_enums(reader.writer_schema)
         results = [self._translate_record(record, enums)
-                   for record in reader if record['name'] != 'metadata']
+                   for record in reader if record['name'] != 'Metadata']
         return results
 
     def _translate_record(self, record, enums):

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -24,7 +24,7 @@ async def test_translate_nothing():
 async def test_ignore_metadata():
     schema = make_pfb_schema()
     file = make_avro_file(schema, [
-        {'name': 'metadata', 'object': {}}
+        {'name': 'Metadata', 'object': {}}
     ])
 
     result = await translate(fastavro.reader(file))


### PR DESCRIPTION
Super small change for something changed recently in Gen3. 

I double-checked with them and they agree that the capitalization should be as it is in https://raw.githubusercontent.com/uc-cdis/pypfb/master/doc/schema.svg?sanitize=true ([backup link](https://github.com/uc-cdis/pypfb/blob/8c33f5e11fc17d2a53d1a49f97ca6d1b4d94fd3a/doc/schema.svg)) All of the names in PFB itself are (apparently) “Darwin case” (see: https://en.wikipedia.org/wiki/Camel_case) … a combination of UpperCamelCase and snake_case. The types in the data dictionary (https://gen3.datastage.io/DD) are all snake_case with no capitalization. These conventions assure that there will be no conflicts between PFB types and data dictionary types.