### PR TITLE
Add singular references [SATURN-1060]

### DIFF
--- a/arrow/translate.py
+++ b/arrow/translate.py
@@ -36,12 +36,16 @@ class Translator:
                 value = 'drs://' + value
             return _make_add_update_op(key, value)
 
-        operations = [make_op(key, value)
+        attributes = [make_op(key, value)
                       for key, value in record['object'].items() if value is not None]
+        relations = [make_op(r['dst_name'],
+                             {'entityType': r['dst_name'], 'entityName': r['dst_id']})
+                     for r in record['relations']]
+
         return {
             'name': name,
             'entityType': entity_type,
-            'operations': operations
+            'operations': [*attributes, *relations]
         }
 
 

--- a/arrow/translate.py
+++ b/arrow/translate.py
@@ -38,9 +38,9 @@ class Translator:
 
         attributes = [make_op(key, value)
                       for key, value in record['object'].items() if value is not None]
-        relations = [make_op(r['dst_name'],
-                             {'entityType': r['dst_name'], 'entityName': r['dst_id']})
-                     for r in record['relations']]
+        relations = [make_op(relation['dst_name'],
+                             {'entityType': relation['dst_name'], 'entityName': relation['dst_id']})
+                     for relation in record['relations']]
 
         return {
             'name': name,


### PR DESCRIPTION
Completes part of https://broadworkbench.atlassian.net/browse/SATURN-1054. This currently supports only singular references, not lists of references.

I experimented with Rawls and discovered that:

1. Repeated references with the same attribute name on the same entity in the same upsert JSON object does not result in any error and simply retains the last one.
2. Forward references to new entities further into the JSON are allowed. References must resolve to an entity by the time the import is complete.