### PR TITLE
Rename name attributes

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,9 +1,8 @@
 runtime: python37
 instance_class: F4
 automatic_scaling:
-  min_instances: 1
-  max_instances: 20
   min_idle_instances: 1
+  max_instances: 20
 inbound_services:
 - warmup
 entrypoint: gunicorn -b :$PORT arrow.server:app --worker-class sanic.worker.GunicornWorker --timeout 120

--- a/arrow/translate.py
+++ b/arrow/translate.py
@@ -34,6 +34,8 @@ class Translator:
                 value = _b64_decode(value).decode("utf-8")
             if self.options['prefix-object-ids'] and key == 'object_id':
                 value = 'drs://' + value
+            if key == 'name':
+                key = entity_type + '_name'
             return _make_add_update_op(key, value)
 
         attributes = [make_op(key, value)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -202,6 +202,25 @@ async def test_make_entity_links():
     ]
 
 
+@pytest.mark.asyncio
+async def test_rename_name_attributes():
+    schema = make_pfb_schema([named_entity_def])
+    file = make_avro_file(schema, [
+        {'name': 'thing', 'id': '1', 'object': {'name': 'Thing 1'}}
+    ])
+
+    result = await translate(fastavro.reader(file))
+    assert result == [
+        {
+            'name': '1',
+            'entityType': 'thing',
+            'operations': [
+                add_update_attribute('thing_name', 'Thing 1')
+            ]
+        }
+    ]
+
+
 person_entity_def = {'name': 'person', 'type': 'record', 'fields': [
     {'name': 'first_name', 'default': None, 'type': ['null', 'string']},
     {'name': 'last_name', 'default': None, 'type': ['null', 'string']},
@@ -212,6 +231,10 @@ person_entity_def = {'name': 'person', 'type': 'record', 'fields': [
 
 pet_entity_def = {'name': 'pet', 'type': 'record', 'fields': [
     {'name': 'pet_name', 'default': None, 'type': ['null', 'string']}
+]}
+
+named_entity_def = {'name': 'thing', 'type': 'record', 'fields': [
+    {'name': 'name', 'type': 'string'}
 ]}
 
 


### PR DESCRIPTION
Rawls expression parsing treats `name` as an alias for the entity ID. Therefore, it rejects attributes named `name`. This prepends the entity type to any attributes named `name`. This comes with the small risk of conflicting with an existing attribute with that name, but this is a small risk and is not a problem for current use cases.

I also tweaked a scaling config to avoid leaving idle instances running for old versions.